### PR TITLE
Fix CORS issue for lightweight-charts import

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,7 +22,8 @@
     <div id="chart"></div>
 
     <script type="module">
-import { createChart } from 'https://unpkg.com/lightweight-charts/dist/lightweight-charts.esm.development.js';
+import { createChart } from
+  'https://cdn.jsdelivr.net/npm/lightweight-charts@5.0.7/dist/lightweight-charts.esm.min.js';
 
 const chart  = createChart(document.getElementById('chart'), { height: 600 });
 const series = chart.addCandlestickSeries();
@@ -31,8 +32,7 @@ const BASE   = 'http://localhost:5000';
 
 async function load(tf) {
   const url = `${BASE}/api/candles?symbol=BTCUSDT&tf=${tf}&limit=500`;
-  console.log('fetch', url);
-  const res  = await fetch(url);
+  const res = await fetch(url);
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   const data = await res.json();
   series.setData(data);


### PR DESCRIPTION
## Summary
- import lightweight-charts from jsDelivr to avoid CORS errors
- remove console logging from API calls

## Testing
- `python -m py_compile backend/app.py backend/db.py`

------
https://chatgpt.com/codex/tasks/task_e_6851c232a2188329b47b9d84f71df4b6