### PR TITLE
Fix CDN path for lightweight-charts

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -23,7 +23,7 @@
 
     <script type="module">
 import { createChart } from
-  'https://cdn.jsdelivr.net/npm/lightweight-charts@5.0.7/dist/lightweight-charts.esm.min.js';
+  'https://cdn.jsdelivr.net/npm/lightweight-charts@5.0.7/dist/lightweight-charts.esm.js';
 
 const chart  = createChart(document.getElementById('chart'), { height: 600 });
 const series = chart.addCandlestickSeries();


### PR DESCRIPTION
## Summary
- update ESM CDN script path in `index.html`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851c9554ddc8329a9c7a84c06aadb20