### PR TITLE
Fix chart loading by updating CDN URL

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -23,7 +23,7 @@
 
     <script type="module">
 import { createChart } from
-  'https://cdn.jsdelivr.net/npm/lightweight-charts@5.0.7/dist/lightweight-charts.esm.js';
+  'https://unpkg.com/lightweight-charts@4.3.0/dist/lightweight-charts.esm.js?module';
 
 const chart  = createChart(document.getElementById('chart'), { height: 600 });
 const series = chart.addCandlestickSeries();


### PR DESCRIPTION
## Summary
- update CDN import to a stable lightweight-charts release to avoid 404

## Testing
- `python -m compileall -q backend`


------
https://chatgpt.com/codex/tasks/task_e_6851ca5c6afc8329b97d1be27d3d4d25