### PR TITLE
Update frontend and docs for local library usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,15 @@ cd frontend
 python -m http.server 8000
 # or open index.html directly in the browser
 ```
+
+## Starta
+1. backend `$ python app.py`
+2. frontend `$ python -m http.server 8000`
+Öppna http://localhost:8000  → grafen visas.
+
+### Ladda ner biblioteket
+Kör i projektroten:
+```bash
+curl -L -o frontend/lightweight-charts.js \
+  https://cdn.jsdelivr.net/npm/lightweight-charts@5.0.7/dist/lightweight-charts.standalone.production.js
+```

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,40 +1,47 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <title>SmartChart</title>
-    <style>
-        body { font-family: sans-serif; margin: 0; padding: 1rem; }
-        #chart { height: 600px; }
-    </style>
+  <meta charset="utf-8" />
+  <title>SmartChart MVP-0</title>
+  <style>
+    body { margin:0; font-family:Arial, sans-serif; }
+    #toolbar { padding:8px }
+    #chart   { height:600px }
+  </style>
 </head>
 <body>
-    <label for="tf">Timeframe:</label>
+  <div id="toolbar">
+    Timeframe:
     <select id="tf">
-        <option value="1m">1m</option>
-        <option value="5m">5m</option>
-        <option value="15m">15m</option>
-        <option value="1h">1h</option>
-        <option value="4h">4h</option>
+      <option value="1m">1m</option>
+      <option value="5m">5m</option>
+      <option value="15m">15m</option>
+      <option value="1h">1h</option>
+      <option value="4h">4h</option>
     </select>
+  </div>
 
-    <div id="chart"></div>
+  <div id="chart"></div>
 
-    <script src="lightweight-charts.js"></script>
-    <script>
-        const chart  = LightweightCharts.createChart(document.getElementById('chart'), { height: 600 });
-        const series = chart.addCandlestickSeries();
-        const tfSel  = document.getElementById('tf');
-        const BASE   = 'http://localhost:5000';
+  <!-- ① Lokal JS-fil – ingen CDN-risk -->
+  <script src="lightweight-charts.js"></script>
 
-        async function load(tf) {
-            const url = `${BASE}/api/candles?symbol=BTCUSDT&tf=${tf}&limit=500`;
-            const res = await fetch(url);
-            if (!res.ok) throw new Error(`HTTP ${res.status}`);
-            series.setData(await res.json());
-        }
-        tfSel.addEventListener('change', () => load(tfSel.value));
-        load(tfSel.value);
-    </script>
+  <!-- ② Vår logik – ligger EFTER biblioteket  -->
+  <script>
+    const chart  = LightweightCharts.createChart(document.getElementById('chart'), { height: 600 });
+    const series = chart.addCandlestickSeries();
+    const tfSel  = document.getElementById('tf');
+    const BASE   = 'http://localhost:5000';
+
+    async function load(tf) {
+      const url = `${BASE}/api/candles?symbol=BTCUSDT&tf=${tf}&limit=500`;
+      const res = await fetch(url);
+      if (!res.ok) { alert(`API fel ${res.status}`); return; }
+      series.setData(await res.json());
+    }
+
+    tfSel.addEventListener('change', () => load(tfSel.value));
+    load(tfSel.value);          // initial
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update `index.html` to load the chart library locally
- document how to run backend and frontend together
- add instructions for downloading lightweight-charts locally

## Testing
- `python -m py_compile backend/app.py backend/db.py`

------
https://chatgpt.com/codex/tasks/task_e_68527873329083298e4bc4c867a6d950